### PR TITLE
Introduce prioritize_animated option + exception handling

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -191,7 +191,10 @@ def get_cached_file(app_name, app_id, image_type, image_num, set_current):
         logger.log(f"get_cached_file(): Invalid index {image_num}")
         return None
 
-    image_url = game_db["games"][app_id_str][type_dict[image_type]][str(image_num)]["url"]
+    try:
+        image_url = game_db["games"][app_id_str][type_dict[image_type]][str(image_num)]["url"]
+    except KeyError:
+        image_url = game_db["games"][app_id_str][type_dict[image_type]][image_num]
     logger.log(f"get_cached_file(): Image URL is {image_url}")
 
     ftype = "png"
@@ -253,13 +256,12 @@ class Backend:
             elif get_config()["prioritize_animated"]:
                 try:
                     images = game_db["games"][str(app_id)][type_dict[image_type]]
+	                for i, image in images.items():
+	                    if image["type"] == "animated":
+	                        cached_file = get_cached_file(app_name, app_id, image_type, int(i), set_current)
+	                        break
                 except KeyError as e:
-                    logger.log(f"get_image() -> No {type_dict[image_type]} found for {app_id}: {app_name}")
-                    images = {}
-                for i, image in images.items():
-                    if image["type"] == "animated":
-                        cached_file = get_cached_file(app_name, app_id, image_type, int(i), set_current)
-                        break
+					logger.log(f"get_image() -> No {type_dict[image_type]} found or old game_db for {app_id}: {app_name}")
 
         if cached_file is not None:
             logger.log("get_image() -> Image exists, returning encoded data")

--- a/config.json
+++ b/config.json
@@ -3,6 +3,7 @@
     "display_name_fallback": true,
     "replace_custom_images": true,
     "appids_excluded_from_replacement": [],
+    "prioritize_animated":  false,
     "grids_config": {
         "nsfw": "false",
         "humor": "any",


### PR DESCRIPTION
### What does this PR do?
Implements a new option "prioritize_animated" which causes the collection grid method to prioritize animated grids and fall back to "0" if no animated grid has been found

It also changes the order of the image urls in the url_list and puts the animated images at the beginning of the list for all image_types, allowing the user to easily go through all animated images on the game specific menu

Also catches an exception thats being thrown when there havent been any images found which prevented the collection grid method from progressing any further 