### PR TITLE
[Feat] New option prioritize_authors

### DIFF
--- a/backend/main.lua
+++ b/backend/main.lua
@@ -44,6 +44,12 @@ function get_encoded_image(img_url)
         return ""
     end
 
+    local raw_size = #response.body
+    if raw_size > 10 * 1024 * 1024 then
+        logger:warn(string.format("Image %d bytes exceeds 10 MB limit, skipping", raw_size))
+        return ""
+    end
+
     return utils.base64_encode(response.body)
 end
 

--- a/frontend/index.tsx
+++ b/frontend/index.tsx
@@ -23,6 +23,7 @@ var pluginConfig = {
     replace_custom_images: true,
     appids_excluded_from_replacement: "",
     prioritize_animated: false,
+    prioritize_authors: [],
     expand_headers: "",
     app_page_button: true,
     grids_config: {
@@ -177,6 +178,21 @@ async function searchAllPages(appId, imgType, typesOverride) {
     return [];
 }
 
+function orderSearchDataByAuthors(searchData: any[]): any[] {
+    const priorityAuthors: string[] = pluginConfig.prioritize_authors;
+    if (priorityAuthors.length > 0) {
+        searchData.sort((a, b) => {
+            const aIdx = priorityAuthors.findIndex(author => a.author?.name?.toLowerCase() === author.toLowerCase());
+            const bIdx = priorityAuthors.findIndex(author => b.author?.name?.toLowerCase() === author.toLowerCase());
+            const aRank = aIdx === -1 ? priorityAuthors.length : aIdx;
+            const bRank = bIdx === -1 ? priorityAuthors.length : bIdx;
+            return aRank - bRank;
+        });
+    }
+
+    return searchData;
+}
+
 async function getSearchData(appId, imgType) {
     if (!(appId.toString() in searchCache)) {
         searchCache[appId.toString()] = {};
@@ -188,16 +204,20 @@ async function getSearchData(appId, imgType) {
 
     let searchData = [];
     if (pluginConfig.prioritize_animated) {
-        const searchDataAnimated = await searchAllPages(appId, imgType, "animated");
+        let searchDataAnimated = await searchAllPages(appId, imgType, "animated");
         for (let i = 0; i < searchDataAnimated.length; i++) {
             searchDataAnimated[i]["type"] = "animated";
         }
-        
+
+        searchDataAnimated = orderSearchDataByAuthors(searchDataAnimated);
+
         let searchDataStatic = await searchAllPages(appId, imgType, "static");
         for (let i = 0; i < searchDataStatic.length; i++) {
             searchDataStatic[i]["type"] = "static";
         }
-        
+
+        searchDataStatic = orderSearchDataByAuthors(searchDataStatic);
+
         searchData = searchDataAnimated.concat(searchDataStatic);
     } else {
         searchData = await searchAllPages(appId, imgType, undefined);
@@ -209,6 +229,8 @@ async function getSearchData(appId, imgType) {
                 searchData[i]["type"] = "static";
             }
         }
+
+        searchData = orderSearchDataByAuthors(searchData);
     }
     searchCache[appId.toString()][imgTypeDict[imgType]] = searchData;
     return searchData;
@@ -580,6 +602,12 @@ const SingleSetting = (props) => {
                 <TextField disabled={isDisabled} defaultValue={pluginConfig[props.parentname][props.name]} onChange={(e: React.ChangeEvent<HTMLInputElement>) => { pluginConfig[props.parentname][props.name] = e.currentTarget.value; saveConfig(); }} />
             </Field>
         );
+    } else if (props.type === "array") {
+        return (
+            <Field label={props.label} description={props.description} bottomSeparator="standard" focusable>
+                <TextField disabled={isDisabled} defaultValue={pluginConfig[props.name].join(", ")} onChange={(e: React.ChangeEvent<HTMLInputElement>) => { pluginConfig[props.name] = e.currentTarget.value.split(",").map(s => s.trim()).filter(s => s.length > 0); saveConfig(); }} />
+            </Field>
+        );
     }
 }
 
@@ -603,6 +631,7 @@ const SettingsContent = () => {
             <SingleSetting name="replace_custom_images" type="bool" readonly={true} label="Always replace cusmtom Images" description="When replacing all grid images, replace custom set ones as well" />
             <SingleSetting name="appids_excluded_from_replacement" type="text" label="Exclude APPIDs from replacement" description="When replacing all grid images, skip these apps (separate by semicolon)" />
             <SingleSetting name="prioritize_animated" type="bool" label="Prioritize animated images" description="Prioritize animated images" />
+            <SingleSetting name="prioritize_authors" type="array" label="Prioritize Authors" description="Prioritize images by author (comma-separated, in order)" />
             <SingleSetting name="expand_headers" type="text" label="Expand app header size" description="Set custom header height" />
             <SingleSetting name="app_page_button" type="bool" label="Show SG button" description="Show SG button on application pages" />
             <ImageSearchSetting name="grids_config" label="Grids" />

--- a/frontend/index.tsx
+++ b/frontend/index.tsx
@@ -98,7 +98,13 @@ async function callAPI(endpoint) {
         console.log("[steam-easygrid 4] Unsuccessful HTTP request");
         return undefined;
     }
-    const apiAnswer = JSON.parse(apiAnswerStr);
+    let apiAnswer;
+    try {
+        apiAnswer = JSON.parse(apiAnswerStr);
+    } catch (e) {
+        console.error("[steam-easygrid 4] Failed to parse API response:", e);
+        return undefined;
+    }
     if ("http_status" in apiAnswer) {
         console.log("[steam-easygrid 4] Unsuccessful API call - HTTP", apiAnswer["http_status"]);
         return undefined;
@@ -127,6 +133,7 @@ async function getSteamGridDBId(appId: number): Promise<number | undefined> {
             return gamesResponse["data"]["id"];
         } else if (pluginConfig.display_name_fallback) {
             const currentApp = appStore.allApps.find((x) => x.appid === appId);
+            if (!currentApp) return undefined;
             const searchResponse = await callAPI(`search/autocomplete/${encodeURIComponent(currentApp.display_name)}`);
             if (searchResponse) {
                 if (searchResponse["data"].length > 0) {
@@ -242,6 +249,46 @@ async function getSearchData(appId, imgType) {
     return searchData;
 }
 
+function getImageExtFromUrl(imgURL: string): string {
+    return imgURL.endsWith(".jpg") || imgURL.endsWith(".jpeg") || imgURL.endsWith(".jfif") ? 'jpg' : 'png';
+}
+
+async function applyFirstWorkingImage(appId: number, imgType: number): Promise<boolean> {
+    const gameId = await getSteamGridDBId(appId);
+    if (!gameId) return false;
+
+    const imgTypeName = imgTypeDict[imgType];
+    const imgSearchTypeName = imgType === 3 ? "grids" : imgTypeName;
+    const usedConfig = pluginConfig[`${imgTypeName}_config`];
+
+    let mimeList = usedConfig.mimes;
+    if (pluginConfig.disable_webp) {
+        mimeList = mimeList.replace("image/webp,", "").replace(",image/webp", "");
+    }
+    const dimStr = "dimensions" in usedConfig ? `&dimensions=${usedConfig.dimensions}` : "";
+    const baseQ = `nsfw=${usedConfig.nsfw}&humor=${usedConfig.humor}&epilepsy=${usedConfig.epilepsy}&mimes=${mimeList}&styles=${usedConfig.styles}${dimStr}`;
+
+    const tryTypes = async (types: string): Promise<boolean> => {
+        for (let page = 0; ; page++) {
+            const result = await callAPI(`${imgSearchTypeName}/game/${gameId}?${baseQ}&types=${types}&page=${page}`);
+            if (!result?.data?.length) return false;
+            for (const item of result.data) {
+                const imageData = await get_encoded_image({ img_url: item.url });
+                if (imageData) {
+                    SteamClient.Apps.SetCustomArtworkForApp(appId, imageData, getImageExtFromUrl(item.url), imgType);
+                    return true;
+                }
+            }
+            if (result.data.length < 50) return false;
+        }
+    };
+
+    if (pluginConfig.prioritize_animated) {
+        return await tryTypes("animated") || await tryTypes("static");
+    }
+    return await tryTypes(usedConfig.types);
+}
+
 async function getImageData(appId, imgType, imgNum) {
     const searchResults = await getSearchData(appId, imgType);
     if (searchResults && searchResults.length > imgNum) {
@@ -283,12 +330,10 @@ async function renderHome(popup: any) {
                     const excludedAppIDs = getExcludedAppIDs();
                     for (let j = 0; j < currentColl.allApps.length; j++) {
                         gridButton.firstChild.innerHTML = `Working... (${j}/${currentColl.allApps.length})`;
-                        if (currentColl.allApps[j].appid in excludedAppIDs) continue;
-                        const newImage = await getImageData(currentColl.allApps[j].appid, 0, 0);
-                        if (newImage) {
-                            const imageExt = await getImageExt(currentColl.allApps[j].appid, 0, 0);
-                            SteamClient.Apps.SetCustomArtworkForApp(currentColl.allApps[j].appid, newImage, imageExt, 0);
-                        }
+                        const appid = currentColl.allApps[j].appid;
+                        if (appid in excludedAppIDs) continue;
+                        await applyFirstWorkingImage(appid, 0);
+                        delete searchCache[appid.toString()];
                     }
                     gridButton.firstChild.innerHTML = "Done!";
                     console.log("[steam-easygrid 4] Grids replaced for", collId);
@@ -332,12 +377,10 @@ async function renderCollection(popup: any) {
                         const excludedAppIDs = getExcludedAppIDs();
                         for (let j = 0; j < currentColl.allApps.length; j++) {
                             gridButton.firstChild.innerHTML = `Working... (${j}/${currentColl.allApps.length})`;
-                            if (currentColl.allApps[j].appid in excludedAppIDs) continue;
-                            const newImage = await getImageData(currentColl.allApps[j].appid, 0, 0);
-                            if (newImage) {
-                                const imageExt = await getImageExt(currentColl.allApps[j].appid, 0, 0);
-                                SteamClient.Apps.SetCustomArtworkForApp(currentColl.allApps[j].appid, newImage, imageExt, 0);
-                            }
+                            const appid = currentColl.allApps[j].appid;
+                            if (appid in excludedAppIDs) continue;
+                            await applyFirstWorkingImage(appid, 0);
+                            delete searchCache[appid.toString()];
                         }
                         gridButton.firstChild.innerHTML = "Done!";
                         console.log("[steam-easygrid 4] Grids replaced for", uiStore.currentGameListSelection.strCollectionId);
@@ -521,20 +564,11 @@ async function renderApp(popup: any) {
                 showContextMenu(
                     <Menu label="SGDB Options">
                         <MenuItem onClick={async () => {
-                            const currentColl = collectionStore.GetCollection(uiStore.currentGameListSelection.strCollectionId);
-                            const currentApp = currentColl.allApps.find((x) => x.appid === uiStore.currentGameListSelection.nAppId);
-
-                            let allImageTypes = 4;
-                            if (pluginConfig.icons_enabled) {
-                                allImageTypes = 5;
-                            }
+                            const allImageTypes = pluginConfig.icons_enabled ? 5 : 4;
+                            const appId = uiStore.currentGameListSelection.nAppId;
                             for (let j = 0; j < allImageTypes; j++) {
                                 gridButton.firstChild.innerHTML = `${j}/${allImageTypes}`;
-                                const newImage = await getImageData(uiStore.currentGameListSelection.nAppId, j, 0);
-                                if (newImage) {
-                                    const imageExt = await getImageExt(uiStore.currentGameListSelection.nAppId, j, 0);
-                                    SteamClient.Apps.SetCustomArtworkForApp(uiStore.currentGameListSelection.nAppId, newImage, imageExt, j);
-                                }
+                                await applyFirstWorkingImage(appId, j);
                             }
                             gridButton.firstChild.innerHTML = "SG";
                             console.log("[steam-easygrid 4] Images replaced for", uiStore.currentGameListSelection.nAppId);

--- a/frontend/index.tsx
+++ b/frontend/index.tsx
@@ -386,14 +386,34 @@ function getEasyGridComponent(popup: any) {
 
         const [steamGridDBId, setSteamGridDBId] = useState<number>(-1);
         const [thumbnailList, setThumbnailList] = useState([]);
+        const [sgdbIdInput, setSteamGridDBIdInput] = useState<string>("");
 
         const GetCurrentSettings = async () => {
-            setSteamGridDBId(await getSteamGridDBId(props.appid));
+            const id = await getSteamGridDBId(props.appid);
+            setSteamGridDBId(id);
+            setSteamGridDBIdInput(id !== undefined ? id.toString() : "");
             setThumbnailList(await getSearchData(props.appid, props.imagetype));
         };
 
         const PurgeImageCache = async () => {
             console.log("[steam-easygrid 4] Purging cache and reloading...");
+            searchCache[props.appid.toString()] = {};
+            GetCurrentSettings();
+        };
+
+        const SetSteamGridDBIdOverride = async () => {
+            const newId = Number(sgdbIdInput);
+            if (!isNaN(newId) && newId > 0) {
+                gameIDOverrides[props.appid.toString()] = newId;
+                localStorage.setItem("luthor112.steam-easygrid.overrides", JSON.stringify(gameIDOverrides));
+                searchCache[props.appid.toString()] = {};
+                GetCurrentSettings();
+            }
+        };
+
+        const ClearSteamGridDBIdOverride = async () => {
+            delete gameIDOverrides[props.appid.toString()];
+            localStorage.setItem("luthor112.steam-easygrid.overrides", JSON.stringify(gameIDOverrides));
             searchCache[props.appid.toString()] = {};
             GetCurrentSettings();
         };
@@ -427,7 +447,10 @@ function getEasyGridComponent(popup: any) {
                 App ID: {props.appid} / SGDB ID: {steamGridDBId} / Image Type: {props.imagetype} (found {thumbnailList.length}) <br/>
                 <DialogButton style={{width: "120px", display: "inline-block"}} onClick={SetOriginalImage}>Reset</DialogButton> &nbsp;
                 <DialogButton style={{width: "120px", display: "inline-block"}} onClick={PurgeImageCache}>Purge Cache</DialogButton> &nbsp;
-                <DialogButton style={{width: "120px", display: "inline-block"}} onClick={OpenWebpage}>Open Webpage</DialogButton><br/>
+                <DialogButton style={{width: "120px", display: "inline-block"}} onClick={OpenWebpage}>Open Webpage</DialogButton>
+                <div style={{maxWidth: "150px", display: "inline-block", marginRight: "35px", marginLeft: "10px"}}><TextField value={sgdbIdInput} onChange={(e: React.ChangeEvent<HTMLInputElement>) => setSteamGridDBIdInput(e.currentTarget.value)} mustBeNumeric={true} /></div>
+                <DialogButton style={{width: "120px", display: "inline-block"}} onClick={SetSteamGridDBIdOverride}>Set SGDB ID</DialogButton> &nbsp;
+                <DialogButton style={{width: "120px", display: "inline-block"}} onClick={ClearSteamGridDBIdOverride}>Clear SGDB ID</DialogButton><br/>
                 <div style={containerStyle}>
                     {thumbnailList.map((thumbData, index) => {
                         if (thumbData["type"] === "static")


### PR DESCRIPTION
### What does this PR do?
1. It adds a new option `prioritize_authors` which is an array (backend)/comma seperated string (frontend) of steamgriddb author names. It allows to show images of prioritized authors at the top. It also respects the `prioritize_animated` option. 

<img width="339" height="257" alt="image" src="https://github.com/user-attachments/assets/8caafcc6-9989-47d0-9305-860cf5934388" />

<img width="1522" height="702" alt="image" src="https://github.com/user-attachments/assets/8d560681-641d-4d98-b643-5583c96009ea" />

2. adds a new input + 2 buttons for overwriting and resetting  the SGDB ID of a game to the easy grid window. allows the user to overwrite a games SGDB ID in case it doesnt match (eg. Wizard of Legend 2 for which SGDB has mapped the wrong game to its steam appid)

3. blocks images bigger than 10MB to prevent IPC related issues. if an image is bigger than 10MB it checks the images next in line instead.