### PR TITLE
fix: bypass Steam libcurl conflict when fetching images

### DIFF
--- a/backend/main.lua
+++ b/backend/main.lua
@@ -1,7 +1,6 @@
 local logger = require("logger")
 local millennium = require("millennium")
 local http = require("http")
-local utils = require("utils")
 
 -- INTERFACES
 
@@ -32,19 +31,51 @@ end
 
 function get_encoded_image(img_url)
     logger:info("Requesting image " .. img_url)
-    local response, err = http.get(img_url)
+    local tmpfile = "/tmp/sgdb_" .. tostring(os.time()) .. ".bin"
 
-    if not response then
-        logger:error(err)
+    local dl_handle = io.popen(string.format(
+        "env -u LD_LIBRARY_PATH curl -s -L --max-time 30 --max-filesize 10485760 -w '%%{http_code}' -o %q %q 2>&1",
+        tmpfile, img_url
+    ))
+    if not dl_handle then
+        logger:error("io.popen unavailable")
+        return ""
+    end
+    local curl_out = dl_handle:read("*a")
+    dl_handle:close()
+
+    if curl_out ~= "200" then
+        logger:error("curl failed or non-200: " .. tostring(curl_out))
+        os.remove(tmpfile)
         return ""
     end
 
-    if response.status ~= 200 then
-        logger:error(string.format("Got HTTP %d", response.status))
+    local sz_h = io.popen(string.format("stat -c%%s %q 2>/dev/null", tmpfile))
+    local fsize = tonumber(sz_h and sz_h:read("*a") or "0") or 0
+    if sz_h then sz_h:close() end
+    if fsize > 10485760 then
+        logger:error(string.format("Image too large (%d bytes), skipping", fsize))
+        os.remove(tmpfile)
         return ""
     end
+    logger:info(string.format("Image size: %d bytes", fsize))
 
-    return utils.base64_encode(response.body)
+    local b64_handle = io.popen(string.format("env -u LD_LIBRARY_PATH base64 -w 0 %q", tmpfile))
+    if not b64_handle then
+        logger:error("base64 popen failed")
+        os.remove(tmpfile)
+        return ""
+    end
+    local b64 = b64_handle:read("*a")
+    b64_handle:close()
+    os.remove(tmpfile)
+
+    logger:info(string.format("Image encoded %d chars", #(b64 or "")))
+    return b64 or ""
+end
+
+function log_frontend(msg)
+    logger:info("[frontend] " .. tostring(msg))
 end
 
 -- PLUGIN MANAGEMENT

--- a/backend/main.lua
+++ b/backend/main.lua
@@ -2,6 +2,11 @@ local logger = require("logger")
 local millennium = require("millennium")
 local http = require("http")
 
+local is_windows = package.config:sub(1, 1) == "\\"
+if is_windows then
+    utils = require("utils")
+end
+
 -- INTERFACES
 
 function call_api_backend(a_bearer, b_endpoint)
@@ -29,8 +34,7 @@ function call_api_backend(a_bearer, b_endpoint)
     return response.body
 end
 
-function get_encoded_image(img_url)
-    logger:info("Requesting image " .. img_url)
+local function get_encoded_image_linux(img_url)
     local tmpfile = "/tmp/sgdb_" .. tostring(os.time()) .. ".bin"
 
     local dl_handle = io.popen(string.format(
@@ -72,6 +76,28 @@ function get_encoded_image(img_url)
 
     logger:info(string.format("Image encoded %d chars", #(b64 or "")))
     return b64 or ""
+end
+
+local function get_encoded_image_windows(img_url)
+    local response, err = http.get(img_url)
+    if not response then
+        logger:error(err)
+        return ""
+    end
+    if response.status ~= 200 then
+        logger:error(string.format("Got HTTP %d", response.status))
+        return ""
+    end
+    return utils.base64_encode(response.body)
+end
+
+function get_encoded_image(img_url)
+    logger:info("Requesting image " .. img_url)
+    if is_windows then
+        return get_encoded_image_windows(img_url)
+    else
+        return get_encoded_image_linux(img_url)
+    end
 end
 
 function log_frontend(msg)

--- a/frontend/index.tsx
+++ b/frontend/index.tsx
@@ -5,6 +5,7 @@ import React, { useState, useEffect } from "react";
 // Backend functions
 const call_api_backend = callable<[{ a_bearer: string, b_endpoint: string }], string>('call_api_backend');
 const get_encoded_image = callable<[{ img_url: string }], string>('get_encoded_image');
+const log_frontend = callable<[{ msg: string }], void>('log_frontend');
 
 const WaitForElement = async (sel: string, parent = document) =>
 	[...(await Millennium.findElement(parent, sel))][0];
@@ -221,10 +222,15 @@ async function getSearchData(appId, imgType) {
 }
 
 async function getImageData(appId, imgType, imgNum) {
+    await log_frontend({ msg: `getImageData appid=${appId} type=${imgType} index=${imgNum}` });
     const searchResults = await getSearchData(appId, imgType);
+    await log_frontend({ msg: `image list length=${searchResults ? searchResults.length : null}` });
     if (searchResults && searchResults.length > imgNum) {
         const imgURL = searchResults[imgNum].url;
-        return await get_encoded_image({ img_url: imgURL });
+        await log_frontend({ msg: `requesting via backend url=${imgURL}` });
+        const b64 = await get_encoded_image({ img_url: imgURL });
+        await log_frontend({ msg: `base64 length=${b64 ? b64.length : 'null'}` });
+        return b64 || undefined;
     }
     return undefined;
 }


### PR DESCRIPTION
## Problem

When applying an image, the backend would crash immediately after `Requesting image ...` with:

```
rpc_client: disconnected while waiting for response
Backend unloaded
```

Querying the SteamGridDB API worked fine — only image fetching failed.

## Root cause (two issues)

1. **Millennium's `http` module crashes on binary responses.** It works fine for JSON (text), but fetching a PNG/JPG body causes the backend to crash entirely, killing the RPC connection.

2. **Steam's `LD_LIBRARY_PATH` injects an old `libcurl`** (`steam-runtime/pinned_libs_64/libcurl.so.4`) that is incompatible with the system `curl` binary:
   ```
   curl: /home/...steam-runtime/pinned_libs_64/libcurl.so.4: version 'CURL_OPENSSL_4' not found
   ```
   This means even bypassing Millennium's http module and shelling out to `curl` fails unless `LD_LIBRARY_PATH` is unset first.

## Fix

- Replaced `http.get` + `utils.base64_encode` in `get_encoded_image` with `io.popen` + `curl` (with `env -u LD_LIBRARY_PATH` to strip Steam's library override) + system `base64 -w 0`
- Added a 10 MB file size cap (`--max-filesize 10485760`) to prevent oversized images from exceeding the RPC transport limit, which caused silent failures after processing very large files
- Added a `log_frontend` RPC helper so frontend log messages appear in Millennium's backend log output alongside other backend messages

## Testing

Confirmed working on CachyOS Linux (Arch-based). Images now apply correctly via the picker and auto-replace buttons.

## Notes

- This fix was developed with AI assistance (Claude Code / Anthropic)
- The `log_frontend` helper is useful for debugging but could be removed if preferred — it adds a small RPC round-trip per log call