### PR TITLE
Fix images not being applied

### DIFF
--- a/backend/main.lua
+++ b/backend/main.lua
@@ -7,11 +7,13 @@ local is_windows = package.config:sub(1, 1) == "\\"
 
 local img_cache = {}
 local CHUNK_SIZE = 6 * 1024 * 1024
+local download_counter = 0
 
 local function make_tmpfile()
+    download_counter = download_counter + 1
     return is_windows and
-        ((os.getenv("TEMP") or os.getenv("TMP") or "C:\\Windows\\Temp") .. "\\sgdb_" .. tostring(os.time()) .. ".bin") or
-        ("/tmp/sgdb_" .. tostring(os.time()) .. ".bin")
+        ((os.getenv("TEMP") or os.getenv("TMP") or "C:\\Windows\\Temp") .. "\\sgdb_" .. tostring(download_counter) .. ".bin") or
+        ("/tmp/sgdb_" .. tostring(download_counter) .. ".bin")
 end
 
 -- INTERFACES

--- a/backend/main.lua
+++ b/backend/main.lua
@@ -3,9 +3,6 @@ local millennium = require("millennium")
 local http = require("http")
 
 local is_windows = package.config:sub(1, 1) == "\\"
-if is_windows then
-    utils = require("utils")
-end
 
 -- INTERFACES
 
@@ -79,23 +76,48 @@ local function get_encoded_image_linux(img_url)
 end
 
 local function get_encoded_image_windows(img_url)
-    local response, err = http.get(img_url)
-    if not response then
-        logger:error(err)
+    local tmpdir = os.getenv("TEMP") or os.getenv("TMP") or "C:\\Windows\\Temp"
+    local tmpfile = tmpdir .. "\\sgdb_" .. tostring(os.time()) .. ".bin"
+
+    local dl_handle = io.popen(string.format(
+        'curl -s -L --max-time 30 --max-filesize 10485760 -w "%%{http_code}" -o "%s" "%s" 2>&1',
+        tmpfile, img_url
+    ))
+    if not dl_handle then
+        logger:error("io.popen unavailable")
         return ""
     end
-    if response.status ~= 200 then
-        logger:error(string.format("Got HTTP %d", response.status))
+    local curl_out = dl_handle:read("*a")
+    dl_handle:close()
+
+    local http_code = curl_out:match("^%s*(.-)%s*$")
+    if http_code ~= "200" then
+        logger:error("curl failed: " .. tostring(curl_out))
+        os.remove(tmpfile)
         return ""
     end
 
-    local raw_size = #response.body
-    if raw_size > 10 * 1024 * 1024 then
-        logger:warn(string.format("Image %d bytes exceeds 10 MB limit, skipping", raw_size))
+    local b64_handle = io.popen(string.format(
+        "powershell -NoProfile -NonInteractive -Command \"[Convert]::ToBase64String([System.IO.File]::ReadAllBytes('%s'))\"",
+        tmpfile
+    ))
+    if not b64_handle then
+        logger:error("powershell popen failed")
+        os.remove(tmpfile)
+        return ""
+    end
+    local b64 = b64_handle:read("*a")
+    b64_handle:close()
+    os.remove(tmpfile)
+
+    b64 = b64:gsub("%s+", "")
+    if b64 == "" then
+        logger:error("base64 encoding produced empty result")
         return ""
     end
 
-    return utils.base64_encode(response.body)
+    logger:info(string.format("Image encoded %d chars", #b64))
+    return b64
 end
 
 function get_encoded_image(img_url)

--- a/backend/main.lua
+++ b/backend/main.lua
@@ -5,6 +5,15 @@ local utils = require("utils")
 
 local is_windows = package.config:sub(1, 1) == "\\"
 
+local img_cache = {}
+local CHUNK_SIZE = 6 * 1024 * 1024
+
+local function make_tmpfile()
+    return is_windows and
+        ((os.getenv("TEMP") or os.getenv("TMP") or "C:\\Windows\\Temp") .. "\\sgdb_" .. tostring(os.time()) .. ".bin") or
+        ("/tmp/sgdb_" .. tostring(os.time()) .. ".bin")
+end
+
 -- INTERFACES
 
 function call_api_backend(a_bearer, b_endpoint)
@@ -32,52 +41,64 @@ function call_api_backend(a_bearer, b_endpoint)
     return response.body
 end
 
-function get_encoded_image(img_url)
-    logger:info("Requesting image " .. img_url)
+function download_image(a_img_url)
+    logger:info("Downloading image " .. a_img_url)
 
-    local tmpfile = is_windows and
-        ((os.getenv("TEMP") or os.getenv("TMP") or "C:\\Windows\\Temp") .. "\\sgdb_" .. tostring(os.time()) .. ".bin") or
-        ("/tmp/sgdb_" .. tostring(os.time()) .. ".bin")
+    if img_cache[a_img_url] then
+        os.remove(img_cache[a_img_url])
+        img_cache[a_img_url] = nil
+    end
 
-    local result, err = http.download(img_url, tmpfile)
+    local tmpfile = make_tmpfile()
+    local result, err = http.download(a_img_url, tmpfile)
     if not result then
         logger:error("http.download failed: " .. tostring(err))
-        return ""
+        return 0
     end
     if result.status ~= 200 then
         logger:error(string.format("Got HTTP %d", result.status))
         os.remove(tmpfile)
-        return ""
+        return 0
     end
-    if result.bytes_written > 10 * 1024 * 1024 then
-        logger:warn(string.format("Image too large (%d bytes), skipping", result.bytes_written))
-        os.remove(tmpfile)
-        return ""
-    end
-    logger:info(string.format("Image size: %d bytes", result.bytes_written))
 
-    local f = io.open(tmpfile, "rb")
-    if not f then
-        logger:error("Could not open temp file: " .. tmpfile)
+    img_cache[a_img_url] = tmpfile
+    logger:info(string.format("Cached %d bytes at %s", result.bytes_written, tmpfile))
+    return result.bytes_written
+end
+
+function get_image_chunk(a_img_url, b_chunk_index)
+    local path = img_cache[a_img_url]
+    if not path then
+        logger:error("No cached image for: " .. a_img_url)
         return ""
     end
-    local data = f:read("*a")
+
+    local f = io.open(path, "rb")
+    if not f then
+        logger:error("Cannot open cached file: " .. path)
+        return ""
+    end
+
+    local offset = b_chunk_index * CHUNK_SIZE
+    f:seek("set", offset)
+    local data = f:read(CHUNK_SIZE)
     f:close()
-    os.remove(tmpfile)
 
     if not data or #data == 0 then
-        logger:error("Temp file is empty")
         return ""
     end
 
     local b64 = utils.base64_encode(data)
-    if not b64 or b64 == "" then
-        logger:error("base64_encode returned empty")
-        return ""
-    end
+    logger:info(string.format("Chunk %d: %d raw bytes → %d b64 chars", b_chunk_index, #data, #(b64 or "")))
+    return b64 or ""
+end
 
-    logger:info(string.format("Image encoded %d chars", #b64))
-    return b64
+function cleanup_image(a_img_url)
+    if img_cache[a_img_url] then
+        logger:info("Cleaning up: " .. img_cache[a_img_url])
+        os.remove(img_cache[a_img_url])
+        img_cache[a_img_url] = nil
+    end
 end
 
 function log_frontend(msg)

--- a/backend/main.lua
+++ b/backend/main.lua
@@ -1,6 +1,7 @@
 local logger = require("logger")
 local millennium = require("millennium")
 local http = require("http")
+local utils = require("utils")
 
 local is_windows = package.config:sub(1, 1) == "\\"
 
@@ -31,102 +32,52 @@ function call_api_backend(a_bearer, b_endpoint)
     return response.body
 end
 
-local function get_encoded_image_linux(img_url)
-    local tmpfile = "/tmp/sgdb_" .. tostring(os.time()) .. ".bin"
+function get_encoded_image(img_url)
+    logger:info("Requesting image " .. img_url)
 
-    local dl_handle = io.popen(string.format(
-        "env -u LD_LIBRARY_PATH curl -s -L --max-time 30 --max-filesize 10485760 -w '%%{http_code}' -o %q %q 2>&1",
-        tmpfile, img_url
-    ))
-    if not dl_handle then
-        logger:error("io.popen unavailable")
+    local tmpfile = is_windows and
+        ((os.getenv("TEMP") or os.getenv("TMP") or "C:\\Windows\\Temp") .. "\\sgdb_" .. tostring(os.time()) .. ".bin") or
+        ("/tmp/sgdb_" .. tostring(os.time()) .. ".bin")
+
+    local result, err = http.download(img_url, tmpfile)
+    if not result then
+        logger:error("http.download failed: " .. tostring(err))
         return ""
     end
-    local curl_out = dl_handle:read("*a")
-    dl_handle:close()
-
-    if curl_out ~= "200" then
-        logger:error("curl failed or non-200: " .. tostring(curl_out))
+    if result.status ~= 200 then
+        logger:error(string.format("Got HTTP %d", result.status))
         os.remove(tmpfile)
         return ""
     end
-
-    local sz_h = io.popen(string.format("stat -c%%s %q 2>/dev/null", tmpfile))
-    local fsize = tonumber(sz_h and sz_h:read("*a") or "0") or 0
-    if sz_h then sz_h:close() end
-    if fsize > 10485760 then
-        logger:error(string.format("Image too large (%d bytes), skipping", fsize))
+    if result.bytes_written > 10 * 1024 * 1024 then
+        logger:warn(string.format("Image too large (%d bytes), skipping", result.bytes_written))
         os.remove(tmpfile)
         return ""
     end
-    logger:info(string.format("Image size: %d bytes", fsize))
+    logger:info(string.format("Image size: %d bytes", result.bytes_written))
 
-    local b64_handle = io.popen(string.format("env -u LD_LIBRARY_PATH base64 -w 0 %q", tmpfile))
-    if not b64_handle then
-        logger:error("base64 popen failed")
-        os.remove(tmpfile)
+    local f = io.open(tmpfile, "rb")
+    if not f then
+        logger:error("Could not open temp file: " .. tmpfile)
         return ""
     end
-    local b64 = b64_handle:read("*a")
-    b64_handle:close()
+    local data = f:read("*a")
+    f:close()
     os.remove(tmpfile)
 
-    logger:info(string.format("Image encoded %d chars", #(b64 or "")))
-    return b64 or ""
-end
-
-local function get_encoded_image_windows(img_url)
-    local tmpdir = os.getenv("TEMP") or os.getenv("TMP") or "C:\\Windows\\Temp"
-    local tmpfile = tmpdir .. "\\sgdb_" .. tostring(os.time()) .. ".bin"
-
-    local dl_handle = io.popen(string.format(
-        'curl -s -L --max-time 30 --max-filesize 10485760 -w "%%{http_code}" -o "%s" "%s" 2>&1',
-        tmpfile, img_url
-    ))
-    if not dl_handle then
-        logger:error("io.popen unavailable")
-        return ""
-    end
-    local curl_out = dl_handle:read("*a")
-    dl_handle:close()
-
-    local http_code = curl_out:match("^%s*(.-)%s*$")
-    if http_code ~= "200" then
-        logger:error("curl failed: " .. tostring(curl_out))
-        os.remove(tmpfile)
+    if not data or #data == 0 then
+        logger:error("Temp file is empty")
         return ""
     end
 
-    local b64_handle = io.popen(string.format(
-        "powershell -NoProfile -NonInteractive -Command \"[Convert]::ToBase64String([System.IO.File]::ReadAllBytes('%s'))\"",
-        tmpfile
-    ))
-    if not b64_handle then
-        logger:error("powershell popen failed")
-        os.remove(tmpfile)
-        return ""
-    end
-    local b64 = b64_handle:read("*a")
-    b64_handle:close()
-    os.remove(tmpfile)
-
-    b64 = b64:gsub("%s+", "")
-    if b64 == "" then
-        logger:error("base64 encoding produced empty result")
+    local b64 = utils.base64_encode(data)
+    if not b64 or b64 == "" then
+        logger:error("base64_encode returned empty")
         return ""
     end
 
     logger:info(string.format("Image encoded %d chars", #b64))
     return b64
-end
-
-function get_encoded_image(img_url)
-    logger:info("Requesting image " .. img_url)
-    if is_windows then
-        return get_encoded_image_windows(img_url)
-    else
-        return get_encoded_image_linux(img_url)
-    end
 end
 
 function log_frontend(msg)

--- a/frontend/index.tsx
+++ b/frontend/index.tsx
@@ -382,6 +382,7 @@ async function applyFirstWorkingImage(appId: number, imgType: number): Promise<b
             for (const item of result.data) {
                 const imageData = await fetchEncodedImage(item.url);
                 if (imageData) {
+                    await SteamClient.Apps.ClearCustomArtworkForApp(appId, imgType);
                     SteamClient.Apps.SetCustomArtworkForApp(appId, imageData, getImageExtFromUrl(item.url), imgType);
                     SetCustomizationState(appId, imgType, true);
                     return true;
@@ -561,7 +562,8 @@ function getEasyGridComponent(popup: any) {
             transform: 'translate(-50%, -50%)',
             color: 'darkgray',
             fontSize: '24px',
-            fontWeight: 'bold'
+            fontWeight: 'bold',
+            pointerEvents: "none",
         };
 
         const [steamGridDBId, setSteamGridDBId] = useState<number>(-1);
@@ -601,12 +603,15 @@ function getEasyGridComponent(popup: any) {
         const SetNewImage = async (e: React.MouseEvent<HTMLElement>) => {
             const targetNum = Number((e.target as HTMLElement).dataset.imageindex);
             console.log("[steam-easygrid 4] Setting image to:", targetNum);
+            const container = (e.target as HTMLElement).parentElement!.parentElement!;
+            container.querySelectorAll<HTMLElement>('.easygrid-status').forEach(el => { el.innerText = ''; });
             ((e.target as HTMLElement).nextElementSibling as HTMLElement)!.innerText = "DOWNLOADING";
             ((e.target as HTMLElement).nextElementSibling as HTMLElement)!.style.color = 'darkgray';
-            
+
             const newImage = await getImageData(props.appid, props.imagetype, targetNum);
             if (newImage) {
                 const imageExt = await getImageExt(props.appid, props.imagetype, targetNum);
+                await SteamClient.Apps.ClearCustomArtworkForApp(props.appid, props.imagetype);
                 SteamClient.Apps.SetCustomArtworkForApp(props.appid, newImage, imageExt!, props.imagetype);
                 SetCustomizationState(props.appid, props.imagetype, true);
 
@@ -648,14 +653,14 @@ function getEasyGridComponent(popup: any) {
                             return (
                                 <div style={imageWrapperStyle}>
                                     <img key={index} data-imageindex={index} src={thumbData["thumb"]} alt={thumbData["type"]} style={imageStyle} onClick={SetNewImage}/>
-                                    <div key={`${index}-status`} style={statusStyle}></div>
+                                    <div key={`${index}-status`} className="easygrid-status" style={statusStyle}></div>
                                 </div>
                             );
 
                         return (
                             <div style={imageWrapperStyle}>
                                 <video key={index} data-imageindex={index} autoPlay loop muted playsInline src={thumbData["thumb"]} title={thumbData["type"]} style={imageStyle} onClick={SetNewImage}/>
-                                <div key={`${index}-status`} style={statusStyle}></div>
+                                <div key={`${index}-status`} className="easygrid-status" style={statusStyle}></div>
                             </div>
                         );
                     })}

--- a/frontend/index.tsx
+++ b/frontend/index.tsx
@@ -11,8 +11,30 @@ declare global {
 
 // Backend functions
 const call_api_backend = callable<[{ a_bearer: string, b_endpoint: string }], string>('call_api_backend');
-const get_encoded_image = callable<[{ img_url: string }], string>('get_encoded_image');
+const download_image = callable<[{ a_img_url: string }], number>('download_image');
+const get_image_chunk = callable<[{ a_img_url: string, b_chunk_index: number }], string>('get_image_chunk');
+const cleanup_image = callable<[{ a_img_url: string }], void>('cleanup_image');
 const log_frontend = callable<[{ msg: string }], void>('log_frontend');
+
+const CHUNK_SIZE_BYTES = 6 * 1024 * 1024;
+
+async function fetchEncodedImage(imgURL: string): Promise<string | undefined> {
+    const size = await download_image({ a_img_url: imgURL });
+    if (!size) return undefined;
+
+    const numChunks = Math.ceil(size / CHUNK_SIZE_BYTES);
+    const parts: string[] = [];
+    for (let i = 0; i < numChunks; i++) {
+        const chunk = await get_image_chunk({ a_img_url: imgURL, b_chunk_index: i });
+        if (!chunk) {
+            await cleanup_image({ a_img_url: imgURL });
+            return undefined;
+        }
+        parts.push(chunk);
+    }
+    await cleanup_image({ a_img_url: imgURL });
+    return parts.join('') || undefined;
+}
 
 const WaitForElement = async (sel: string, parent = document) =>
 	[...(await Millennium.findElement(parent, sel))][0];
@@ -358,7 +380,7 @@ async function applyFirstWorkingImage(appId: number, imgType: number): Promise<b
             const result = await callAPI(`${imgSearchTypeName}/game/${gameId}?${baseQ}&types=${types}&page=${page}`);
             if (!result?.data?.length) return false;
             for (const item of result.data) {
-                const imageData = await get_encoded_image({ img_url: item.url });
+                const imageData = await fetchEncodedImage(item.url);
                 if (imageData) {
                     SteamClient.Apps.SetCustomArtworkForApp(appId, imageData, getImageExtFromUrl(item.url), imgType);
                     SetCustomizationState(appId, imgType, true);
@@ -382,9 +404,9 @@ async function getImageData(appId: number, imgType: number, imgNum: number) {
     if (searchResults && searchResults.length > imgNum) {
         const imgURL = searchResults[imgNum].url;
         await log_frontend({ msg: `requesting via backend url=${imgURL}` });
-        const b64 = await get_encoded_image({ img_url: imgURL });
+        const b64 = await fetchEncodedImage(imgURL);
         await log_frontend({ msg: `base64 length=${b64 ? b64.length : 'null'}` });
-        return b64 || undefined;
+        return b64;
     }
     return undefined;
 }


### PR DESCRIPTION
basically applies the same fix as we already had for linux and therefore merges both the windows and linux function back into one

now also adds chunking which allows us to set images that are bigger than 10MB again!

now clearing the artwork before setting a new one. there currently seems to be a steam/millennium related bug which either requires pressing the reset button or reloading the game view to see the freshly set artwork. so i decided to instead reset/clear it before we set the new one